### PR TITLE
Treat false as a provided value

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -17,5 +17,6 @@ if Mix.env() == :test do
     system_key_with_integer_type: {:system, "INTEGER_ENV_VAR", type: :integer}
 
   config :confix,
-    flat_config_key: "flat value"
+    flat_config_key: "flat value",
+    flat_config_key_false: false
 end

--- a/lib/confix/confix.ex
+++ b/lib/confix/confix.ex
@@ -122,7 +122,10 @@ defmodule Confix do
   Same as `get/2` but raises `Confix.KeyError` if config is missing.
   """
   def get!(key, opts \\ []) do
-    get(key, opts) || raise(KeyError, key_or_keys: key)
+    case get(key, opts) do
+      nil -> raise(KeyError, key_or_keys: key)
+      value -> value
+    end
   end
 
   defp get_app_name(opts) do

--- a/test/confix/confix_test.exs
+++ b/test/confix/confix_test.exs
@@ -33,6 +33,10 @@ defmodule ConfixTest do
         Confix.get!(:flat_config_key_missing)
       end
     end
+
+    test "doesn't raise for false" do
+      assert Confix.get!(:flat_config_key_false) == false
+    end
   end
 
   describe "get_in/2" do


### PR DESCRIPTION
In `Confix.get!/2` we treat any falsy value as missing - but sometimes a boolean `false` is a correct value (e.g. for `*_enabled` configuration keys). This change makes `Confix.get!/2` treat `false` as a valid value.