### PR TITLE
chore: pin GitHub Actions to immutable commit SHAs

### DIFF
--- a/.github/actions.lock.yaml
+++ b/.github/actions.lock.yaml
@@ -1,12 +1,12 @@
 version: 1
-generated_at: 2026-06-11T15:37:30Z
+generated_at: 2026-06-15T13:14:37Z
 internal: []
 trusted:
   - action: actions/checkout
     refs:
-      - v2.3.4
+      - 5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
     occurrences:
-      v2.3.4:
+      5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f:
         .github/workflows/ci.yml:
           - jobs.mix_test.steps.[0].uses
           - jobs.mix_credo.steps.[0].uses

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           - elixir: 1.11.2
             otp: 23.0.2
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
       - name: Install Dependencies
         run: |
           mix local.rebar --force
@@ -54,7 +54,7 @@ jobs:
           - elixir: 1.11.2
             otp: 23.0.2
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
       - name: Install Dependencies
         run: |
           mix local.rebar --force
@@ -75,5 +75,5 @@ jobs:
           - elixir: 1.11.2
             otp: 23.0.2
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
       - run: mix format --check-formatted


### PR DESCRIPTION
## Summary
- Pins **all** GitHub Actions to immutable commit SHAs — both external third-party actions and internal `platform-tribe-actions` references

## How it was generated

The following commands were run in sequence from the repository root:

```
node platform-tribe-actions/.scripts/actions-lockfile-produce.js
node platform-tribe-actions/.scripts/actions-lockfile-bump-internal.js
node platform-tribe-actions/.scripts/actions-lockfile-produce.js
node platform-tribe-actions/.scripts/actions-lockfile-pin-external.js --pin-all
node platform-tribe-actions/.scripts/actions-lockfile-produce.js
```

- `actions-lockfile-produce.js` — generates/updates `.github/actions.lock.yaml` from current workflow refs
- `actions-lockfile-bump-internal.js` — resolves internal (`platform-tribe-actions`) action refs to their current SHA
- `actions-lockfile-pin-external.js --pin-all` — resolves all external action refs to their current SHA